### PR TITLE
chore: update Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jadolg/go-tun2socks
 
-go 1.19
+go 1.26.2
 
 require (
 	github.com/jackpal/gateway v1.0.7


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.2**.

### Changes
- go.mod: go 1.19 → go 1.26.2

_Automated PR by update-go-version.sh_